### PR TITLE
add arguments to dw_create_chart

### DIFF
--- a/R/dw_create_chart.R
+++ b/R/dw_create_chart.R
@@ -3,24 +3,33 @@
 #' Creates and returns the metadata of the new Datawrapper chart.
 #'
 #' @param api_key Optional. A Datawrapper-API-key as character string. Defaults to "environment" - tries to automatically retrieve the key that's stored in the .Reviron-file by \code{\link{datawrapper_auth}}.
+#' @param title Optional. Will set a chart's title on creation.
+#' @param type Optional. Changes the type of the chart. See \href{https://developer.datawrapper.de/docs/chart-types-2}{the documentation} for the different types.
 #'
 #' @return A list with the elements from the Datawrapper-API, the same as in dw_retrieve_chart_metadata()
 #' @author Benedict Witzenberger
-#' @note This function retrieves all metadata about the new chart that's stored by Datawrapper. The new chart will by default be created without a title and with the type d3-lines.
+#' @note This function retrieves all metadata about the new chart that's stored by Datawrapper. If not specified, the new chart will by default be created without a title and with the type d3-lines.
 #' @examples
 #'
-#' dw_create_chart() # uses the preset key in the .Renviron-file
+#' \dontrun{dw_create_chart()} # uses the preset key in the .Renviron-file
+#' \dontrun{dw_create_chart(title = "Testtitle")}
 #'
 #' dw_create_chart(api_key = "1234ABCD") # uses the specified key
 #' @rdname dw_create_chart
 #' @export
-dw_create_chart <- function(api_key = "environment") {
+dw_create_chart <- function(api_key = "environment", title = "", type = "") {
 
   if (api_key == "environment") {
     api_key <- dw_get_api_key()
   }
 
-  r <- httr::POST("https://api.datawrapper.de/charts", httr::add_headers(Authorization = paste("Bearer", api_key, sep = " ")))
+  call_body <- list(metadata = list())
+
+  if (title != "") {call_body <- rlist::list.append(call_body, title = title)}
+  if (type != "") {call_body <- rlist::list.append(call_body, type = type)}
+
+  r <- httr::POST("https://api.datawrapper.de/charts", httr::add_headers(Authorization = paste("Bearer", api_key, sep = " ")),
+                  body = call_body, encode = "json")
 
   try(if(httr::status_code(r) != 200) stop("Fehler bei der Verbindung. Statuscode ist nicht 200."))
 

--- a/R/dw_data_to_chart.R
+++ b/R/dw_data_to_chart.R
@@ -14,6 +14,7 @@
 #' @note This function uploads a R-dataframe to Datawrapper.
 #' @examples
 #'
+#'
 #' \dontrun{dw_data_to_chart(df, "aBcDE")} # uses the preset key in the .Renviron-file
 #'
 #' \dontrun{dw_data_to_chart(df, chart_id = "a1B2Cd", api_key = "1234ABCD")} # uses the specified key

--- a/R/dw_edit_chart.R
+++ b/R/dw_edit_chart.R
@@ -7,7 +7,7 @@
 #' @param title Optional. Adds a title to the plot.
 #' @param intro Optional. Adds an intro below the title.
 #' @param annotate Optional. Adds a annotation below the plot.
-#' @param type Optional. Changes the type of the chart. See \href{https://developer.datawrapper.de/docs/chart-types-2}{the documentation} for the ids.
+#' @param type Optional. Changes the type of the chart. See \href{https://developer.datawrapper.de/docs/chart-types-2}{the documentation} for the different types.
 #' @param source_name Optional. Adds a source name to the plot.
 #' @param source_url Optional. Adds a URL to the source name (displayed only, if source name specified). Include http(s):// before URL.
 #' @param data Optional. A list. Add separate arguments for the data. See \href{https://developer.datawrapper.de/docs/chart-properties-1}{the documentation} for details.
@@ -21,12 +21,12 @@
 #' @note Check their \href{https://developer.datawrapper.de/docs/reference-guide}{reference guide for examples}.
 #' @examples
 #'
-#' dw_edit_chart("aBcDE") # uses the preset key in the .Renviron-file
+#' \dontrun{dw_edit_chart("aBcDE")} # uses the preset key in the .Renviron-file
 #'
-#' dw_edit_chart(chart_id = "a1B2Cd", api_key = "1234ABCD") # uses the specified key
+#' \dontrun{dw_edit_chart(chart_id = "a1B2Cd", api_key = "1234ABCD")} # uses the specified key
 #'
-#' dw_edit_chart(chart_id = "a1B2Cd", title = "I'm a title",
-#' intro = "Data showing daily results") # changes title and intro
+#' \dontrun{dw_edit_chart(chart_id = "a1B2Cd", title = "I'm a title",
+#' intro = "Data showing daily results")} # changes title and intro
 #'
 #' \dontrun{dw_edit_chart(chart_id = "a1B2Cd", title = "I'm a title",
 #' visualize = list(`show-tooltips` = "false"))} # adds manual changes as lists

--- a/R/dw_get_api_key.R
+++ b/R/dw_get_api_key.R
@@ -7,7 +7,8 @@
 #' @note This is a helper function, that shouldn't be of any use outside of this package.
 #' @examples
 #'
-#' dw_get_api_key()
+#' \dontrun{dw_get_api_key()}
+#'
 #' @rdname dw_get_api_key
 #' @export
 dw_get_api_key <- function() {

--- a/R/dw_publish_chart.R
+++ b/R/dw_publish_chart.R
@@ -11,11 +11,11 @@
 #' @note This function publishes a chart in Datawrapper.
 #' @examples
 #'
-#' dw_publish_chart("aBcDE") # uses the preset key in the .Renviron-file
+#' \dontrun{dw_publish_chart("aBcDE")} # uses the preset key in the .Renviron-file
 #'
-#' dw_publish_chart(chart_id = "a1B2Cd", api_key = "1234ABCD") # uses the specified key
+#' \dontrun{dw_publish_chart(chart_id = "a1B2Cd", api_key = "1234ABCD")} # uses the specified key
 #'
-#' dw_publish_chart(chart_id = "a1B2Cd", return_urls = TRUE) # won't return code and URLs for chart
+#' \dontrun{dw_publish_chart(chart_id = "a1B2Cd", return_urls = TRUE)} # won't return code and URLs for chart
 #'
 #' @rdname dw_publish_chart
 #' @export

--- a/docs/reference/dw_create_chart.html
+++ b/docs/reference/dw_create_chart.html
@@ -117,7 +117,7 @@
     <p>Creates and returns the metadata of the new Datawrapper chart.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>dw_create_chart</span>(<span class='kw'>api_key</span> <span class='kw'>=</span> <span class='st'>"environment"</span>)</pre>
+    <pre class="usage"><span class='fu'>dw_create_chart</span>(<span class='kw'>api_key</span> <span class='kw'>=</span> <span class='st'>"environment"</span>, <span class='kw'>title</span> <span class='kw'>=</span> <span class='st'>""</span>, <span class='kw'>type</span> <span class='kw'>=</span> <span class='st'>""</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -126,6 +126,14 @@
       <th>api_key</th>
       <td><p>Optional. A Datawrapper-API-key as character string. Defaults to "environment" - tries to automatically retrieve the key that's stored in the .Reviron-file by <code><a href='datawrapper_auth.html'>datawrapper_auth</a></code>.</p></td>
     </tr>
+    <tr>
+      <th>title</th>
+      <td><p>Optional. Will set a chart's title on creation.</p></td>
+    </tr>
+    <tr>
+      <th>type</th>
+      <td><p>Optional. Changes the type of the chart. See <a href='https://developer.datawrapper.de/docs/chart-types-2'>the documentation</a> for the different types.</p></td>
+    </tr>
     </table>
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
@@ -133,187 +141,20 @@
     <p>A list with the elements from the Datawrapper-API, the same as in dw_retrieve_chart_metadata()</p>
     <h2 class="hasAnchor" id="note"><a class="anchor" href="#note"></a>Note</h2>
 
-    <p>This function retrieves all metadata about the new chart that's stored by Datawrapper. The new chart will by default be created without a title and with the type d3-lines.</p>
+    <p>This function retrieves all metadata about the new chart that's stored by Datawrapper. If not specified, the new chart will by default be created without a title and with the type d3-lines.</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'>
-<span class='fu'>dw_create_chart</span>() <span class='co'># uses the preset key in the .Renviron-file</span></div><div class='output co'>#&gt; [1] "New chart's id: 2N6CY"</div><div class='output co'>#&gt; $status
+<span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_create_chart</span>() <span class='co'># uses the preset key in the .Renviron-file</span>
+<span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_create_chart</span>(<span class='kw'>title</span> <span class='kw'>=</span> <span class='st'>"Testtitle"</span>)
+
+<span class='fu'>dw_create_chart</span>(<span class='kw'>api_key</span> <span class='kw'>=</span> <span class='st'>"1234ABCD"</span>) <span class='co'># uses the specified key</span></div><div class='output co'>#&gt; [1] "New chart's id: C6JzZ"</div><div class='output co'>#&gt; $status
 #&gt; [1] "ok"
 #&gt; 
 #&gt; $data
 #&gt; $data[[1]]
 #&gt; $data[[1]]$id
-#&gt; [1] "2N6CY"
-#&gt; 
-#&gt; $data[[1]]$title
-#&gt; [1] "[ Insert title here ]"
-#&gt; 
-#&gt; $data[[1]]$theme
-#&gt; [1] "sddeutsche-digital-test"
-#&gt; 
-#&gt; $data[[1]]$createdAt
-#&gt; [1] "2019-10-31 09:43:17"
-#&gt; 
-#&gt; $data[[1]]$lastModifiedAt
-#&gt; [1] "2019-10-31 09:43:17"
-#&gt; 
-#&gt; $data[[1]]$type
-#&gt; [1] "d3-lines"
-#&gt; 
-#&gt; $data[[1]]$metadata
-#&gt; $data[[1]]$metadata$data
-#&gt; $data[[1]]$metadata$data$transpose
-#&gt; [1] FALSE
-#&gt; 
-#&gt; $data[[1]]$metadata$data$`vertical-header`
-#&gt; [1] TRUE
-#&gt; 
-#&gt; $data[[1]]$metadata$data$`horizontal-header`
-#&gt; [1] TRUE
-#&gt; 
-#&gt; 
-#&gt; $data[[1]]$metadata$visualize
-#&gt; $data[[1]]$metadata$visualize$`highlighted-series`
-#&gt; list()
-#&gt; 
-#&gt; $data[[1]]$metadata$visualize$`highlighted-values`
-#&gt; list()
-#&gt; 
-#&gt; 
-#&gt; $data[[1]]$metadata$describe
-#&gt; $data[[1]]$metadata$describe$`source-name`
-#&gt; [1] ""
-#&gt; 
-#&gt; $data[[1]]$metadata$describe$`source-url`
-#&gt; [1] ""
-#&gt; 
-#&gt; $data[[1]]$metadata$describe$`number-format`
-#&gt; [1] "-"
-#&gt; 
-#&gt; $data[[1]]$metadata$describe$`number-divisor`
-#&gt; [1] 0
-#&gt; 
-#&gt; $data[[1]]$metadata$describe$`number-append`
-#&gt; [1] ""
-#&gt; 
-#&gt; $data[[1]]$metadata$describe$`number-prepend`
-#&gt; [1] ""
-#&gt; 
-#&gt; $data[[1]]$metadata$describe$intro
-#&gt; [1] ""
-#&gt; 
-#&gt; $data[[1]]$metadata$describe$byline
-#&gt; [1] ""
-#&gt; 
-#&gt; 
-#&gt; $data[[1]]$metadata$publish
-#&gt; $data[[1]]$metadata$publish$`embed-width`
-#&gt; [1] 600
-#&gt; 
-#&gt; $data[[1]]$metadata$publish$`embed-height`
-#&gt; [1] 400
-#&gt; 
-#&gt; 
-#&gt; $data[[1]]$metadata$annotate
-#&gt; $data[[1]]$metadata$annotate$notes
-#&gt; [1] ""
-#&gt; 
-#&gt; 
-#&gt; $data[[1]]$metadata$json_error
-#&gt; NULL
-#&gt; 
-#&gt; 
-#&gt; $data[[1]]$authorId
-#&gt; [1] 66969
-#&gt; 
-#&gt; $data[[1]]$showInGallery
-#&gt; [1] FALSE
-#&gt; 
-#&gt; $data[[1]]$language
-#&gt; [1] "de-DE"
-#&gt; 
-#&gt; $data[[1]]$guestSession
-#&gt; NULL
-#&gt; 
-#&gt; $data[[1]]$lastEditStep
-#&gt; [1] 0
-#&gt; 
-#&gt; $data[[1]]$publishedAt
-#&gt; NULL
-#&gt; 
-#&gt; $data[[1]]$publicUrl
-#&gt; [1] "https://s3.eu-central-1.amazonaws.com/datawrapper-charts/static/2N6CY/index.html"
-#&gt; 
-#&gt; $data[[1]]$publicVersion
-#&gt; [1] 0
-#&gt; 
-#&gt; $data[[1]]$organizationId
-#&gt; [1] "sueddeutsche"
-#&gt; 
-#&gt; $data[[1]]$forkedFrom
-#&gt; NULL
-#&gt; 
-#&gt; $data[[1]]$externalData
-#&gt; NULL
-#&gt; 
-#&gt; $data[[1]]$forkable
-#&gt; [1] FALSE
-#&gt; 
-#&gt; $data[[1]]$isFork
-#&gt; [1] FALSE
-#&gt; 
-#&gt; $data[[1]]$inFolder
-#&gt; NULL
-#&gt; 
-#&gt; $data[[1]]$utf8
-#&gt; [1] FALSE
-#&gt; 
-#&gt; $data[[1]]$author
-#&gt; $data[[1]]$author$id
-#&gt; [1] 66969
-#&gt; 
-#&gt; $data[[1]]$author$email
-#&gt; [1] "benedict.witzenberger@sueddeutsche.de"
-#&gt; 
-#&gt; $data[[1]]$author$name
-#&gt; NULL
-#&gt; 
-#&gt; $data[[1]]$author$website
-#&gt; NULL
-#&gt; 
-#&gt; $data[[1]]$author$socialmedia
-#&gt; NULL
-#&gt; 
-#&gt; $data[[1]]$author$isLoggedIn
-#&gt; [1] TRUE
-#&gt; 
-#&gt; $data[[1]]$author$isGuest
-#&gt; [1] FALSE
-#&gt; 
-#&gt; $data[[1]]$author$isActivated
-#&gt; [1] TRUE
-#&gt; 
-#&gt; $data[[1]]$author$isAdmin
-#&gt; [1] FALSE
-#&gt; 
-#&gt; $data[[1]]$author$organization
-#&gt; $data[[1]]$author$organization$id
-#&gt; [1] "sueddeutsche"
-#&gt; 
-#&gt; $data[[1]]$author$organization$name
-#&gt; [1] "Süddeutsche Zeitung"
-#&gt; 
-#&gt; 
-#&gt; 
-#&gt; 
-#&gt; </div><div class='input'>
-<span class='fu'>dw_create_chart</span>(<span class='kw'>api_key</span> <span class='kw'>=</span> <span class='st'>"1234ABCD"</span>) <span class='co'># uses the specified key</span></div><div class='output co'>#&gt; [1] "New chart's id: GsPVI"</div><div class='output co'>#&gt; $status
-#&gt; [1] "ok"
-#&gt; 
-#&gt; $data
-#&gt; $data[[1]]
-#&gt; $data[[1]]$id
-#&gt; [1] "GsPVI"
+#&gt; [1] "C6JzZ"
 #&gt; 
 #&gt; $data[[1]]$title
 #&gt; [1] "[ Insert title here ]"
@@ -322,10 +163,10 @@
 #&gt; [1] "datawrapper-data"
 #&gt; 
 #&gt; $data[[1]]$createdAt
-#&gt; [1] "2019-10-31 09:43:17"
+#&gt; [1] "2019-10-31 16:22:41"
 #&gt; 
 #&gt; $data[[1]]$lastModifiedAt
-#&gt; [1] "2019-10-31 09:43:17"
+#&gt; [1] "2019-10-31 16:22:41"
 #&gt; 
 #&gt; $data[[1]]$type
 #&gt; [1] "d3-lines"
@@ -403,7 +244,7 @@
 #&gt; [1] "en-US"
 #&gt; 
 #&gt; $data[[1]]$guestSession
-#&gt; [1] "b2pege483qdetp47gq6th43vcd"
+#&gt; [1] "mjqocvspmc4qntlssj8d3dkjp7"
 #&gt; 
 #&gt; $data[[1]]$lastEditStep
 #&gt; [1] 0
@@ -412,7 +253,7 @@
 #&gt; NULL
 #&gt; 
 #&gt; $data[[1]]$publicUrl
-#&gt; [1] "https://s3.eu-central-1.amazonaws.com/datawrapper-charts/static/GsPVI/index.html"
+#&gt; [1] "https://s3.eu-central-1.amazonaws.com/datawrapper-charts/static/C6JzZ/index.html"
 #&gt; 
 #&gt; $data[[1]]$publicVersion
 #&gt; [1] 0

--- a/docs/reference/dw_data_to_chart.html
+++ b/docs/reference/dw_data_to_chart.html
@@ -152,6 +152,7 @@
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'>
+
 <span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_data_to_chart</span>(<span class='no'>df</span>, <span class='st'>"aBcDE"</span>) <span class='co'># uses the preset key in the .Renviron-file</span>
 
 <span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_data_to_chart</span>(<span class='no'>df</span>, <span class='kw'>chart_id</span> <span class='kw'>=</span> <span class='st'>"a1B2Cd"</span>, <span class='kw'>api_key</span> <span class='kw'>=</span> <span class='st'>"1234ABCD"</span>) <span class='co'># uses the specified key</span>

--- a/docs/reference/dw_edit_chart.html
+++ b/docs/reference/dw_edit_chart.html
@@ -157,7 +157,7 @@
     </tr>
     <tr>
       <th>type</th>
-      <td><p>Optional. Changes the type of the chart. See <a href='https://developer.datawrapper.de/docs/chart-types-2'>the documentation</a> for the ids.</p></td>
+      <td><p>Optional. Changes the type of the chart. See <a href='https://developer.datawrapper.de/docs/chart-types-2'>the documentation</a> for the different types.</p></td>
     </tr>
     <tr>
       <th>source_name</th>
@@ -195,16 +195,13 @@
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'>
-<span class='fu'>dw_edit_chart</span>(<span class='st'>"aBcDE"</span>) <span class='co'># uses the preset key in the .Renviron-file</span></div><div class='output co'>#&gt; Error in if (chart_id != chart_id_response) stop("The chart_ids between call and response do not match. Try again and check API.") : 
-#&gt;   Argument hat Länge 0
-#&gt; [1] "Chart  succesfully updated."</div><div class='input'>
-<span class='fu'>dw_edit_chart</span>(<span class='kw'>chart_id</span> <span class='kw'>=</span> <span class='st'>"a1B2Cd"</span>, <span class='kw'>api_key</span> <span class='kw'>=</span> <span class='st'>"1234ABCD"</span>) <span class='co'># uses the specified key</span></div><div class='output co'>#&gt; Error in if (chart_id != chart_id_response) stop("The chart_ids between call and response do not match. Try again and check API.") : 
-#&gt;   Argument hat Länge 0
-#&gt; [1] "Chart  succesfully updated."</div><div class='input'>
-<span class='fu'>dw_edit_chart</span>(<span class='kw'>chart_id</span> <span class='kw'>=</span> <span class='st'>"a1B2Cd"</span>, <span class='kw'>title</span> <span class='kw'>=</span> <span class='st'>"I'm a title"</span>,
-<span class='kw'>intro</span> <span class='kw'>=</span> <span class='st'>"Data showing daily results"</span>) <span class='co'># changes title and intro</span></div><div class='output co'>#&gt; Error in if (chart_id != chart_id_response) stop("The chart_ids between call and response do not match. Try again and check API.") : 
-#&gt;   Argument hat Länge 0
-#&gt; [1] "Chart  succesfully updated."</div><div class='input'>
+<span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_edit_chart</span>(<span class='st'>"aBcDE"</span>) <span class='co'># uses the preset key in the .Renviron-file</span>
+
+<span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_edit_chart</span>(<span class='kw'>chart_id</span> <span class='kw'>=</span> <span class='st'>"a1B2Cd"</span>, <span class='kw'>api_key</span> <span class='kw'>=</span> <span class='st'>"1234ABCD"</span>) <span class='co'># uses the specified key</span>
+
+<span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_edit_chart</span>(<span class='kw'>chart_id</span> <span class='kw'>=</span> <span class='st'>"a1B2Cd"</span>, <span class='kw'>title</span> <span class='kw'>=</span> <span class='st'>"I'm a title"</span>,
+<span class='kw'>intro</span> <span class='kw'>=</span> <span class='st'>"Data showing daily results"</span>) <span class='co'># changes title and intro</span>
+
 <span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_edit_chart</span>(<span class='kw'>chart_id</span> <span class='kw'>=</span> <span class='st'>"a1B2Cd"</span>, <span class='kw'>title</span> <span class='kw'>=</span> <span class='st'>"I'm a title"</span>,
 <span class='kw'>visualize</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(<span class='kw'>`show-tooltips`</span> <span class='kw'>=</span> <span class='st'>"false"</span>)) <span class='co'># adds manual changes as lists</span></div></pre>
   </div>

--- a/docs/reference/dw_get_api_key.html
+++ b/docs/reference/dw_get_api_key.html
@@ -129,7 +129,7 @@
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'>
-<span class='fu'>dw_get_api_key</span>()</div><div class='output co'>#&gt; [1] "c6207ffcb97469dee1d38e7448f62518e8d098a028348c83788d6bdd633a2777"</div></pre>
+<span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_get_api_key</span>()</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>

--- a/docs/reference/dw_publish_chart.html
+++ b/docs/reference/dw_publish_chart.html
@@ -145,13 +145,11 @@
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'>
-<span class='fu'>dw_publish_chart</span>(<span class='st'>"aBcDE"</span>) <span class='co'># uses the preset key in the .Renviron-file</span></div><div class='output co'>#&gt; [1] "Chart aBcDE published!"
-#&gt; [1] "### Responsive iFrame-code: ###\n\n\n### Chart-URL:###\n"</div><div class='input'>
-<span class='fu'>dw_publish_chart</span>(<span class='kw'>chart_id</span> <span class='kw'>=</span> <span class='st'>"a1B2Cd"</span>, <span class='kw'>api_key</span> <span class='kw'>=</span> <span class='st'>"1234ABCD"</span>) <span class='co'># uses the specified key</span></div><div class='output co'>#&gt; [1] "Chart a1B2Cd published!"
-#&gt; [1] "### Responsive iFrame-code: ###\n\n\n### Chart-URL:###\n"</div><div class='input'>
-<span class='fu'>dw_publish_chart</span>(<span class='kw'>chart_id</span> <span class='kw'>=</span> <span class='st'>"a1B2Cd"</span>, <span class='kw'>return_urls</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>) <span class='co'># won't return code and URLs for chart</span></div><div class='output co'>#&gt; [1] "Chart a1B2Cd published!"
-#&gt; [1] "### Responsive iFrame-code: ###\n\n\n### Chart-URL:###\n"</div><div class='input'>
-</div></pre>
+<span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_publish_chart</span>(<span class='st'>"aBcDE"</span>) <span class='co'># uses the preset key in the .Renviron-file</span>
+
+<span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_publish_chart</span>(<span class='kw'>chart_id</span> <span class='kw'>=</span> <span class='st'>"a1B2Cd"</span>, <span class='kw'>api_key</span> <span class='kw'>=</span> <span class='st'>"1234ABCD"</span>) <span class='co'># uses the specified key</span>
+
+<span class='kw'>if</span> (<span class='fl'>FALSE</span>) <span class='fu'>dw_publish_chart</span>(<span class='kw'>chart_id</span> <span class='kw'>=</span> <span class='st'>"a1B2Cd"</span>, <span class='kw'>return_urls</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>) <span class='co'># won't return code and URLs for chart</span></div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>

--- a/man/dw_create_chart.Rd
+++ b/man/dw_create_chart.Rd
@@ -4,10 +4,14 @@
 \alias{dw_create_chart}
 \title{Creates a new Datawrapper chart}
 \usage{
-dw_create_chart(api_key = "environment")
+dw_create_chart(api_key = "environment", title = "", type = "")
 }
 \arguments{
 \item{api_key}{Optional. A Datawrapper-API-key as character string. Defaults to "environment" - tries to automatically retrieve the key that's stored in the .Reviron-file by \code{\link{datawrapper_auth}}.}
+
+\item{title}{Optional. Will set a chart's title on creation.}
+
+\item{type}{Optional. Changes the type of the chart. See \href{https://developer.datawrapper.de/docs/chart-types-2}{the documentation} for the different types.}
 }
 \value{
 A list with the elements from the Datawrapper-API, the same as in dw_retrieve_chart_metadata()
@@ -16,11 +20,12 @@ A list with the elements from the Datawrapper-API, the same as in dw_retrieve_ch
 Creates and returns the metadata of the new Datawrapper chart.
 }
 \note{
-This function retrieves all metadata about the new chart that's stored by Datawrapper. The new chart will by default be created without a title and with the type d3-lines.
+This function retrieves all metadata about the new chart that's stored by Datawrapper. If not specified, the new chart will by default be created without a title and with the type d3-lines.
 }
 \examples{
 
-dw_create_chart() # uses the preset key in the .Renviron-file
+\dontrun{dw_create_chart()} # uses the preset key in the .Renviron-file
+\dontrun{dw_create_chart(title = "Testtitle")}
 
 dw_create_chart(api_key = "1234ABCD") # uses the specified key
 }

--- a/man/dw_data_to_chart.Rd
+++ b/man/dw_data_to_chart.Rd
@@ -28,6 +28,7 @@ This function uploads a R-dataframe to Datawrapper.
 }
 \examples{
 
+
 \dontrun{dw_data_to_chart(df, "aBcDE")} # uses the preset key in the .Renviron-file
 
 \dontrun{dw_data_to_chart(df, chart_id = "a1B2Cd", api_key = "1234ABCD")} # uses the specified key

--- a/man/dw_edit_chart.Rd
+++ b/man/dw_edit_chart.Rd
@@ -30,7 +30,7 @@ dw_edit_chart(
 
 \item{annotate}{Optional. Adds a annotation below the plot.}
 
-\item{type}{Optional. Changes the type of the chart. See \href{https://developer.datawrapper.de/docs/chart-types-2}{the documentation} for the ids.}
+\item{type}{Optional. Changes the type of the chart. See \href{https://developer.datawrapper.de/docs/chart-types-2}{the documentation} for the different types.}
 
 \item{source_name}{Optional. Adds a source name to the plot.}
 
@@ -57,12 +57,12 @@ Check their \href{https://developer.datawrapper.de/docs/reference-guide}{referen
 }
 \examples{
 
-dw_edit_chart("aBcDE") # uses the preset key in the .Renviron-file
+\dontrun{dw_edit_chart("aBcDE")} # uses the preset key in the .Renviron-file
 
-dw_edit_chart(chart_id = "a1B2Cd", api_key = "1234ABCD") # uses the specified key
+\dontrun{dw_edit_chart(chart_id = "a1B2Cd", api_key = "1234ABCD")} # uses the specified key
 
-dw_edit_chart(chart_id = "a1B2Cd", title = "I'm a title",
-intro = "Data showing daily results") # changes title and intro
+\dontrun{dw_edit_chart(chart_id = "a1B2Cd", title = "I'm a title",
+intro = "Data showing daily results")} # changes title and intro
 
 \dontrun{dw_edit_chart(chart_id = "a1B2Cd", title = "I'm a title",
 visualize = list(`show-tooltips` = "false"))} # adds manual changes as lists

--- a/man/dw_get_api_key.Rd
+++ b/man/dw_get_api_key.Rd
@@ -17,7 +17,8 @@ This is a helper function, that shouldn't be of any use outside of this package.
 }
 \examples{
 
-dw_get_api_key()
+\dontrun{dw_get_api_key()}
+
 }
 \author{
 Benedict Witzenberger

--- a/man/dw_publish_chart.Rd
+++ b/man/dw_publish_chart.Rd
@@ -24,11 +24,11 @@ This function publishes a chart in Datawrapper.
 }
 \examples{
 
-dw_publish_chart("aBcDE") # uses the preset key in the .Renviron-file
+\dontrun{dw_publish_chart("aBcDE")} # uses the preset key in the .Renviron-file
 
-dw_publish_chart(chart_id = "a1B2Cd", api_key = "1234ABCD") # uses the specified key
+\dontrun{dw_publish_chart(chart_id = "a1B2Cd", api_key = "1234ABCD")} # uses the specified key
 
-dw_publish_chart(chart_id = "a1B2Cd", return_urls = TRUE) # won't return code and URLs for chart
+\dontrun{dw_publish_chart(chart_id = "a1B2Cd", return_urls = TRUE)} # won't return code and URLs for chart
 
 }
 \author{


### PR DESCRIPTION
# Description

Adds `title` and `type` as arguments to the dw-create_chart-function. Both have just been part of the dw_edit_chart-function. This makes it possible to set a title and a type when creating a chart.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

Documentation has been updated.