### PR TITLE
Fix broken link to Datwrapper chart type docs

### DIFF
--- a/man/dw_create_chart.Rd
+++ b/man/dw_create_chart.Rd
@@ -11,7 +11,7 @@ dw_create_chart(api_key = "environment", title = "", type = "", folderId = "")
 
 \item{title}{Optional. Will set a chart's title on creation.}
 
-\item{type}{Optional. Changes the type of the chart. E.g. "d3-bars" for bars, "tables" for a table. Default is "d3-lines". See \href{https://developer.datawrapper.de/docs/chart-types-2}{the documentation} for the different types.}
+\item{type}{Optional. Changes the type of the chart. E.g. "d3-bars" for bars, "tables" for a table. Default is "d3-lines". See \href{https://developer.datawrapper.de/docs/chart-types}{the documentation} for the different types.}
 
 \item{folderId}{Optional. Creates chart in specified folder.}
 }


### PR DESCRIPTION
The Datawrapper chart type docs are at https://developer.datawrapper.de/docs/chart-types. This may have changed with the 3.0 release. 