### PR TITLE
(live system) test case and fix for repeated 401 issue after dw_publish_chart

### DIFF
--- a/R/dw_publish_chart.R
+++ b/R/dw_publish_chart.R
@@ -34,6 +34,10 @@ dw_publish_chart <- function(chart_id, api_key = "environment", return_urls = TR
 
   parsed <- dw_handle_errors(r)
 
+  httr::handle_reset("https://api.datawrapper.de/")
+
+  parsed
+
   if (httr::status_code(r) == 200) {
     print(paste0("Chart ", chart_id, " published!"))
 
@@ -48,5 +52,4 @@ dw_publish_chart <- function(chart_id, api_key = "environment", return_urls = TR
   } else {
     warning("There has been an error in the publication process.", immediate. = TRUE)
   }
-
 }

--- a/tests/testthat/test-multiple-edits.R
+++ b/tests/testthat/test-multiple-edits.R
@@ -1,0 +1,30 @@
+test_that("Multiple charts can be edited and sent data", {
+  # two charts that you have access to, but were created by a different user
+  chart_1 <- Sys.getenv('DW_TEST_CHART1', '3aW91')
+  chart_2 <- Sys.getenv('DW_TEST_CHART2', 'TInvx')
+
+  data_1 <- data.frame(
+    names=c('never', 'gonna'),
+    values=c(1,2)
+  )
+
+  data_2 <- data.frame(
+    names=c('give', 'you', 'up'),
+    values=c(100, 99, 88)
+  )
+
+  dw_data_to_chart(data_1, chart_1)
+  dw_edit_chart(chart_1, title='never gonna',
+                intro='let',
+                source_name = 'you',
+                annotate = 'down')
+  dw_publish_chart(chart_1)
+
+  dw_data_to_chart(data_2, chart_2)
+  dw_edit_chart(chart_2, # without fix, test fails here
+                title='never gonna',
+                intro='run around',
+                source_name='and',
+                annotate='desert you')
+  dw_publish_chart(chart_2)
+})


### PR DESCRIPTION
should fix #31.

to reproduce issue
- create two charts one account from the same team
- run the test with a different account from the same team
- edit chart ids in test or set them as env vars `DW_TEST_CHART1` and `DW_TEST_CHART2`

test should fail unless the published change to `dw_publish_chart`

thanks for the great library!