### PR TITLE
Fix. Add label to the web link in the docs of `dw_invite_user`.

### DIFF
--- a/R/dw_invite_user.R
+++ b/R/dw_invite_user.R
@@ -6,7 +6,7 @@
 #'
 #' @param team Required. The team-id (can be found in the URL of a teams-folder) as character.
 #' @param email Required. The email-address that gets an invitation as character.
-#' @param role Required. Set to one of: \code{member}, \code{admin}, \code{owner}. Check this for more informations: \href{https://academy.datawrapper.de/article/212-how-to-invite-others-to-a-team}
+#' @param role Required. Set to one of: \code{member}, \code{admin}, \code{owner}. Check this for more informations: \href{https://academy.datawrapper.de/article/212-how-to-invite-others-to-a-team}{How to invite others to a team}
 #' @param api_key Optional. A Datawrapper-API-key as character string. Defaults to "environment" - tries to automatically retrieve the key that's stored in the .Reviron-file by \code{\link{datawrapper_auth}}.
 #'
 #' @return A message of failure or success, derived from the API's status code.

--- a/man/dw_invite_user.Rd
+++ b/man/dw_invite_user.Rd
@@ -16,7 +16,7 @@ dw_invite_user(
 
 \item{email}{Required. The email-address that gets an invitation as character.}
 
-\item{role}{Required. Set to one of: \code{member}, \code{admin}, \code{owner}. Check this for more informations: \href{https://academy.datawrapper.de/article/212-how-to-invite-others-to-a-team}}
+\item{role}{Required. Set to one of: \code{member}, \code{admin}, \code{owner}. Check this for more informations: \href{https://academy.datawrapper.de/article/212-how-to-invite-others-to-a-team}{How to invite others to a team}}
 
 \item{api_key}{Optional. A Datawrapper-API-key as character string. Defaults to "environment" - tries to automatically retrieve the key that's stored in the .Reviron-file by \code{\link{datawrapper_auth}}.}
 }


### PR DESCRIPTION
This PR proposes a small fix in the docs of `dw_invite_user` by adding a label to the web link and to silent the warning

> Warning: /private/var/folders/r3/fpdjtyw91fzfwkwwlpb2tql40000gn/T/RtmpcwXHAc/Rbuild3ae411c233ac/DatawRappr/man/dw_invite_user.Rd:19: unexpected '}', expecting TEXT or '{' 

raised when running `devtools:.check()`.

According to the roxygen [Text formatting reference sheet](https://roxygen2.r-lib.org/articles/formatting.html) a label seems to be required and is required to actually show the link in the docs, i.e. as of the moment no link is displayed in the [docs](https://munichrocker.github.io/DatawRappr/reference/dw_invite_user.html) or `?DatawRappr::dw_invite_user()`.